### PR TITLE
[#2] Integrate with Read The Docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,13 @@
+# .readthedocs.yml
+
+version: 2
+
+python:
+    version: 3.7
+    install:
+        - method: setuptools
+          path: .
+    system_packages: true
+
+sphinx:
+    configuration: sphinxdocs/conf.py

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,12 @@
 CHANGES
 =======
 
+1.0.1
+-----
+
+- Integrate with Read The Docs
+
 1.0
 ---
 
-  - Add Initial content
+- Add Initial content

--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,13 @@
 .. image:: https://travis-ci.org/nokia/fixtureresources.svg?branch=master
     :target: https://travis-ci.org/nokia/fixtureresources
 
+Documentation
+-------------
+
+Documentation for fixtureresouces can be found from `Read The Docs`_.
+
+.. _Read The Docs: http://fixtureresources.readthedocs.io/
+
 Pytest fixtures and helpers
 ---------------------------
 
@@ -19,4 +26,6 @@ Development practices
 ---------------------
 
 The development and the testing follows the Common Robot Libraries development
-practices defined in https://github.com/nokia/crl-devutils.
+practices defined in crl-devutils_.
+
+.. _crl-devutils: http://crl-devutils.readthedocs.io/.

--- a/src/fixtureresources/_version.py
+++ b/src/fixtureresources/_version.py
@@ -1,5 +1,5 @@
 __copyright__ = 'Copyright (C) 2019, Nokia'
-VERSION = '1.0'
+VERSION = '1.0.1'
 GITHASH = ''
 
 


### PR DESCRIPTION
Add Read The Docs configuration and link to README.rst to the
documentation in Read The Docs.